### PR TITLE
Add: appConfig interface and object

### DIFF
--- a/src/utils/appConfig.ts
+++ b/src/utils/appConfig.ts
@@ -1,0 +1,53 @@
+import dotenv from "dotenv";
+
+interface IAppConfig {
+  express: {
+    serverPort: string | undefined;
+    corsOrigin: string | undefined;
+  };
+  logger: {
+    logLevel: string | undefined;
+    logLocation: string | undefined;
+  };
+  database: {
+    name: string;
+    user: string;
+    password: string;
+    host: string;
+    port: number;
+    dialect: string;
+  };
+}
+
+/* Load environment variables. If we're not running in a production environment, then
+ * get the variables from a .env file. Otherwise, use the deployed environment. */
+if (
+  process.env.NODE_ENV !== "production" &&
+  process.env.NODE_ENV !== "testci"
+) {
+  const configOutput = dotenv.config({ path: `.env.${process.env.NODE_ENV}` });
+  if (configOutput.error) {
+    throw new Error("Error loading environment variables");
+  }
+}
+
+const appConfig: IAppConfig = {
+  express: {
+    serverPort: process.env.SERVER_PORT,
+    corsOrigin: process.env.CORS_ORIGIN,
+  },
+  logger: {
+    logLevel: process.env.LOG_LEVEL,
+    logLocation: process.env.LOG_LOCATION,
+  },
+  database: {
+    name: process.env.DATABASE_NAME as string,
+    user: process.env.DATABASE_USER as string,
+    password: process.env.DATABASE_PASSWORD as string,
+    host: process.env.DATABASE_HOST as string,
+    port: parseInt(process.env.DATABASE_PORT as string, 10),
+    dialect: process.env.DATABASE_DIALECT as string,
+  },
+};
+
+export { appConfig, IAppConfig };


### PR DESCRIPTION
This commit adds an appConfig object which is loaded with environment variables when it is imported.

Closes #1. 