### PR TITLE
Add: error handler

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 import logger from "@utils/logger";
+import ErrorHandler from "@utils/errors/errorHandler";
 
 logger.info("Hello World!");
 
@@ -8,10 +9,12 @@ const gracefulShutdown = (cause: string) => {
 
 process.on("uncaughtException", (err) => {
   logger.error(err);
+  ErrorHandler.handleError(err, null);
 });
 
 process.on("unhandledRejection", (err) => {
   logger.error(err);
+  ErrorHandler.handleError(err as Error, null);
 });
 
 process.on("SIGTERM", () => gracefulShutdown("app termination"));

--- a/src/utils/errors/appError.ts
+++ b/src/utils/errors/appError.ts
@@ -1,0 +1,28 @@
+import { type HttpCode } from "@utils/errors/errorTypes";
+
+class AppError extends Error {
+  public readonly name: string;
+
+  public readonly httpCode: HttpCode;
+
+  public readonly isOperational: boolean;
+
+  constructor(
+    name: string,
+    httpCode: HttpCode,
+    description: string,
+    isOperational: boolean,
+  ) {
+    super(description);
+
+    Object.setPrototypeOf(this, new.target.prototype);
+
+    this.name = name;
+    this.httpCode = httpCode;
+    this.isOperational = isOperational;
+
+    Error.captureStackTrace(this);
+  }
+}
+
+export default AppError;

--- a/src/utils/errors/errorHandler.ts
+++ b/src/utils/errors/errorHandler.ts
@@ -1,0 +1,37 @@
+import { Response } from "express";
+import logger from "@utils/logger";
+import AppError from "./appError";
+import { commonHttpErrors } from "./errorTypes";
+
+class ErrorHandler {
+  private static async crashIfUntrustedErrorOrSendResponse(
+    error: Error,
+    response: Response | null,
+  ) {
+    if (!response || !ErrorHandler.isTrustedError(error)) {
+      process.exit(1);
+    }
+    if (error instanceof AppError) {
+      return response
+        .status(error.httpCode)
+        .json({ message: error.message, errorType: error.name });
+    }
+    return response
+      .status(commonHttpErrors.internalServerError)
+      .json("Internal server error");
+  }
+
+  private static isTrustedError(error: Error) {
+    if (error instanceof AppError) {
+      return error.isOperational;
+    }
+    return false;
+  }
+
+  public static async handleError(error: Error, response: Response | null) {
+    logger.error(error);
+    await ErrorHandler.crashIfUntrustedErrorOrSendResponse(error, response);
+  }
+}
+
+export default ErrorHandler;

--- a/src/utils/errors/errorTypes.ts
+++ b/src/utils/errors/errorTypes.ts
@@ -1,0 +1,33 @@
+type HttpCode = number;
+
+interface CommonErrorName {
+  ok: string;
+  notFound: string;
+  internalServerError: string;
+}
+
+interface CommonHttpError {
+  ok: HttpCode;
+  notFound: HttpCode;
+  internalServerError: HttpCode;
+}
+
+const commonErrorNames: CommonErrorName = {
+  ok: "ok",
+  notFound: "Not found",
+  internalServerError: "Internal server error",
+};
+
+const commonHttpErrors: CommonHttpError = {
+  ok: 200,
+  notFound: 404,
+  internalServerError: 500,
+};
+
+export {
+  type HttpCode,
+  type CommonHttpError,
+  type CommonErrorName,
+  commonHttpErrors,
+  commonErrorNames,
+};


### PR DESCRIPTION
This commit adds the AppError class and an error handler. There are also enums for common HTTP error codes and names.

When the application terminates due to uncaught exceptions or unhandled rejections, those errors will be fed to the error handler.

Closes #5.